### PR TITLE
Update Args.hs

### DIFF
--- a/graphmod-plugin/src/Args.hs
+++ b/graphmod-plugin/src/Args.hs
@@ -34,7 +34,7 @@ data IgnoreSpec = IgnoreAll | IgnoreSome [String]  deriving Show
 type OptT = Opts -> Opts
 
 defaultLocation :: FilePath
-defaultLocation = "/root/graphmod-plugin/output"
+defaultLocation = "/tmp/graphmod-plugin/output"
 
 default_opts :: Opts
 default_opts = Opts
@@ -52,7 +52,7 @@ default_opts = Opts
   }
 
 options :: [OptDescr OptT]
-options =
+options =+447961764649
   [ Option ['i'] ["indir"] (ReqArg add_indir "DIR")
     "Directory where the plugin placed the files"
   , Option ['q'] ["quiet"] (NoArg set_quiet)

--- a/graphmod-plugin/src/Args.hs
+++ b/graphmod-plugin/src/Args.hs
@@ -52,7 +52,7 @@ default_opts = Opts
   }
 
 options :: [OptDescr OptT]
-options =+447961764649
+options =
   [ Option ['i'] ["indir"] (ReqArg add_indir "DIR")
     "Directory where the plugin placed the files"
   , Option ['q'] ["quiet"] (NoArg set_quiet)


### PR DESCRIPTION
This seems to need to be an absolute path.  (Built with `cabal build all --allow-newer`.)  But it will break (`createDirectory: does not exist (No such file or directory)`) if `/root` doesn't exist.